### PR TITLE
Update Ledger.ts

### DIFF
--- a/src/ledgers/Ledger.ts
+++ b/src/ledgers/Ledger.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { OfflineSigner } from 'src/proto-signing';
+import { OfflineSigner } from '../proto-signing';
 
 export default abstract class Ledger {
 


### PR DESCRIPTION
Import should be relative because `tsc` can't find the import when cudojs is used as a dependency.

> node_modules/cudosjs/build/ledgers/Ledger.d.ts:2:31 - error TS2307: Cannot find module 'src/proto-signing' or its corresponding type declarations.
> 2 import { OfflineSigner } from 'src/proto-signing';

