### PR TITLE
CUDOS-1535: Update address byte length encoding check

### DIFF
--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -13,7 +13,7 @@ export function isValidAddress(address: string, requiredPrefix?: string): boolea
         if (prefix !== requiredPrefix) {
             return false;
         }
-        return data.length === 20;
+        return data.length === 20 || data.length === 32;
     } catch {
       return false;
     }


### PR DESCRIPTION
Add 32-byte length to accepted encoding for address when checking its validity.